### PR TITLE
@fix\en.json\ERROR_404_BACK

### DIFF
--- a/en.json
+++ b/en.json
@@ -1,6 +1,6 @@
 {
     "WEBSITE_TITLE": "DED STARK - OFFICIAL WEBSITE",
-    "NAVBAR_HOME": "Home",
+    "NAVBAR_HOME": "Homepage",
     "NAVBAR_SHOP": "Shop",
     "NAVBAR_MUSIC": "Music",
     "NAVBAR_TOUR": "Tour",


### PR DESCRIPTION
Found a typo in en.json.
The variable ERROR_404_BACK originally said "Go back to the hommepage." and i changed it to "Go back to the homepage.".
The world "homepage" only contains one 'M'.
Proof: https://www.dict.cc/englisch-deutsch/homepage.html
@torbenhaack